### PR TITLE
Add information about deploying with Capistrano

### DIFF
--- a/docs/additional-reading/deployment.md
+++ b/docs/additional-reading/deployment.md
@@ -90,3 +90,21 @@ bundle
 bin/rake db:setup
 bin/rake db:migrate
 ```
+# Capistrano Deployment
+Make sure ReactOnRails is working in development environment.
+
+Add the following to development your Gemfile and bundle install.
+``` ruby
+group :development do
+  gem 'capistrano-yarn'
+end
+```
+Then run Bundler to ensure Capistrano is downloaded and installed.
+``` sh
+$ bundle install
+```
+Add the following in your Capfile.
+``` ruby
+require 'capistrano/yarn'
+```
+If the deployment is taking too long or getting stuck at assets:precompile stage, it probably is because of memory. Webpack consumes a lot of memory so if possible, try increasing the RAM of your server. 


### PR DESCRIPTION
I could not find any details regarding deploying with Capistrano in the repository. Following the tutorial results in the following error at assets:precompile stage. 

> No such file or directory - /node_modules/.bin/webpack


Because node_modules are usually not checked in the repo, It can't find webpack. Adding `capistrano-yarn` basically adds a task that runs `yarn install` before running webpack.